### PR TITLE
Remove check-stored-locally endpoint

### DIFF
--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { grenacheClientService } = require('../services')
-const { success } = require('../services/helpers')
+const { success } = require('../services/helpers/responses')
 
 const jsonRpc = async (req, res) => {
   const body = { ...req.body }

--- a/src/controllers/base.controller.js
+++ b/src/controllers/base.controller.js
@@ -1,50 +1,7 @@
 'use strict'
 
-const {
-  grenacheClientService: gClientService,
-  helpers
-} = require('../services')
-const { success } = helpers.responses
-
-const checkStoredLocally = async (req, res) => {
-  const body = { ...req.body }
-  const { id = null } = body
-
-  const queryS3 = {
-    action: 'lookUpFunction',
-    args: [{
-      params: { service: 'rest:ext:s3' }
-    }]
-  }
-  const querySendgrid = {
-    action: 'lookUpFunction',
-    args: [{
-      params: { service: 'rest:ext:sendgrid' }
-    }]
-  }
-  const queryGetUser = {
-    action: 'verifyUser',
-    args: [body]
-  }
-
-  const countS3Services = await gClientService
-    .request(queryS3)
-  const countSendgridServices = await gClientService
-    .request(querySendgrid)
-
-  if (
-    !countS3Services ||
-    !countSendgridServices
-  ) {
-    success(200, { result: false, id }, res)
-
-    return
-  }
-
-  const { email } = await gClientService
-    .request(queryGetUser)
-  success(200, { result: email, id }, res)
-}
+const { grenacheClientService } = require('../services')
+const { success } = require('../services/helpers')
 
 const jsonRpc = async (req, res) => {
   const body = { ...req.body }
@@ -58,12 +15,11 @@ const jsonRpc = async (req, res) => {
     args: [body]
   }
 
-  const result = await gClientService.request(query)
+  const result = await grenacheClientService.request(query)
 
   success(200, { result, id }, res)
 }
 
 module.exports = {
-  checkStoredLocally,
   jsonRpc
 }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,7 +9,6 @@ const { asyncErrorCatcher } = require('../services/helpers')
 const controllers = require('../controllers')
 const baseController = asyncErrorCatcher(controllers.baseController)
 
-router.post('/check-stored-locally', baseController.checkStoredLocally)
 router.post('/json-rpc', baseController.jsonRpc)
 
 /**

--- a/src/services/prepareErrorData.service.js
+++ b/src/services/prepareErrorData.service.js
@@ -26,6 +26,10 @@ const _isDuringSyncMethodAccessError = (err) => {
   return /ERR_DURING_SYNC_METHOD_IS_NOT_AVAILABLE/.test(err.toString())
 }
 
+const _isUserWasPreviouslyStoredInDbError = (err) => {
+  return /ERR_USER_WAS_PREVIOUSLY_STORED_IN_DB/.test(err.toString())
+}
+
 module.exports = (error, log = logger) => {
   const err = error instanceof Error
     ? error
@@ -55,6 +59,10 @@ module.exports = (error, log = logger) => {
   if (_isDuringSyncMethodAccessError(err)) {
     err.statusCode = 400
     err.statusMessage = 'Sync with db is taking place, please wait till sync is completed and then try again'
+  }
+  if (_isUserWasPreviouslyStoredInDbError(err)) {
+    err.statusCode = 409
+    err.statusMessage = 'User was previously stored in DB'
   }
 
   return {


### PR DESCRIPTION
This PR removes `/check-stored-locally` endpoint and adds error to show user was previously stored in db when sign-up